### PR TITLE
Fix README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Customer-Segmentantion
+# Customer-Segmentation
 Utilizing pandas, numpy, scikit-learn, and seaborn, this script performs customer segmentation. Techniques like PCA and Standard Scaling enhance data interpretability. Matplotlib and seaborn provide visualization, while tkinter offers a simple GUI. Aimed at identifying patterns for targeted marketing and informed decision-making.


### PR DESCRIPTION
## Summary
- fix heading typo in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407fc6bc44832ca3f8337429b398f2